### PR TITLE
Update VSConfigFinder.nuspec

### DIFF
--- a/pkg/VSConfigFinder/VSConfigFinder.nuspec
+++ b/pkg/VSConfigFinder/VSConfigFinder.nuspec
@@ -5,7 +5,7 @@
     <version>$Version$</version>
     <title>Visual Studio Configuration Finder</title>
     <authors>Microsoft</authors>
-    <owners>Microsoft</owners>
+    <owners>VisualStudioSetup</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://go.microsoft.com/fwlink/?linkid=839265</iconUrl>
     <licenseUrl>https://github.com/Microsoft/VSConfigFinder/tree/$CommitId$/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
The 'owners' field should reflect the maintainer name(s)

## What?
Improve Chocolatey package by resolving a warning

## Why?
Your Chocolatey username is 'VisualStudioSetup` - that's what should be in the owners field. 
